### PR TITLE
modify env_exports

### DIFF
--- a/bin/export_env_dir
+++ b/bin/export_env_dir
@@ -2,7 +2,7 @@
 
 export_env_dir() {
   env_dir=$1
-  whitelist_regex=${2:-''}
+  whitelist_regex=${2:-'^(CF_ZONE_ID|CF_AUTH_KEY|CF_EMAIL)$'}
   blacklist_regex=${3:-'^(env_exports|PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH)$'}
   if [ -d "$env_dir" ]; then
     for e in $(ls $env_dir); do


### PR DESCRIPTION
# 方針
env_exportsの実行中に、一部の環境変数でエラーがでるため、buildpackの実行に必要な環境変数だけexportするように修正
